### PR TITLE
Added importance levels 

### DIFF
--- a/mloggers/_log_levels.py
+++ b/mloggers/_log_levels.py
@@ -1,31 +1,35 @@
-from aenum import Enum, extend_enum
 
+from aenum import Enum, extend_enum
+from numpy import inf
+from typing import Dict
 
 class LogLevel(Enum):
     """
     The available log levels.
-    Each level is associated with a color.
+    Each level is associated with a color and an importance level.
+    The importance level is used to set the minimum level of logs to display (all logs higher than the set level will be displayed).
     To register a new level use `mloggers.register_level`.
     """
 
-    WARN = "yellow"
-    ERROR = "red"
-    DEBUG = "magenta"
-    INFO = "cyan"
+    WARN = {"color": "yellow", "level": 1}
+    ERROR = {"color": "red", "level": inf}
+    DEBUG = {"color": "magenta", "level": -1}
+    INFO = {"color": "cyan", "level": 0}
 
 
-def register_level(level: str, color: str):
+def register_level(level: str, level_info: Dict):
     """
     Register a customized logger level, which will then be available as a member of `LogLevel`,
-    where its `name` is the argument `level` and its `value` is the argument `color`.
+    where its `name` is the argument `level` and its `value` is the argument `level_info`.
     Note: the name of the level will be uppercased.
 
     ### Parameters
     ----------
     `level`: the level name to register.
-    `color`: the color to use for the level.
-    - It must be a valid color name from the `termcolor` package.
+    `level_info`: a dictionary with the following
+        - `color`: the color to use when printing the log. (It must be a valid color name from the `termcolor` package.)
+        - `level`: the importance level of the log. (It must be a number or `np.inf`.)
     """
 
     level = level.upper()
-    extend_enum(LogLevel, level, color)
+    extend_enum(LogLevel, level, level_info)

--- a/mloggers/console_logger.py
+++ b/mloggers/console_logger.py
@@ -10,6 +10,8 @@ from mloggers.logger import Logger
 
 class ConsoleLogger(Logger):
     """Logs to the console (i.e., standard I/O)."""
+    def __init__(self, default_level: LogLevel = LogLevel.INFO):
+        super().__init__(default_level)
 
     def log(
         self,
@@ -18,7 +20,8 @@ class ConsoleLogger(Logger):
         *args: Any,
         **kwargs: Any,
     ):
-        super(ConsoleLogger, self).log(message, level, *args, **kwargs)
+        if not super(ConsoleLogger, self).log(message, level, *args, **kwargs):
+            return
 
         time = "[" + datetime.now().strftime("%H:%M:%S") + "]"
 
@@ -34,7 +37,7 @@ class ConsoleLogger(Logger):
 
             # Color the level string
             if isinstance(level, LogLevel):
-                level_clr = colored(level_str, level.value)
+                level_clr = colored(level_str, level.value["color"])
             else:
                 level_clr = colored(level_str, "green")
 

--- a/mloggers/file_logger.py
+++ b/mloggers/file_logger.py
@@ -13,7 +13,7 @@ from mloggers.logger import Logger
 class FileLogger(Logger):
     """Logs to a file."""
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, default_level: LogLevel | int = LogLevel.INFO):
         """
         Initializes a file logger.
 
@@ -21,13 +21,19 @@ class FileLogger(Logger):
         ----------
         `file_path`: the path to the file to log to.
         - The file will be created if it does not exist. If it does, the logs will be appended to it.
+
+        `default_level`: the default log level to use.
         """
+
+        super().__init__(default_level)
 
         # Create the file if it does not exist
         if not os.path.exists(file_path):
             dir_path = os.path.dirname(file_path)
             try:
-                os.makedirs(dir_path)
+                # If dir path is empty, it means the file is in the current directory
+                if dir_path != "":
+                    os.makedirs(dir_path)
             except FileExistsError:
                 pass
             with open(file_path, "w") as file:
@@ -44,7 +50,8 @@ class FileLogger(Logger):
         *args: Any,
         **kwargs: Any,
     ):
-        super(FileLogger, self).log(message, level, *args, **kwargs)
+        if not super(FileLogger, self).log(message, level, *args, **kwargs):
+            return
 
         # Convert numpy's ndarrays to lists so that they are JSON serializable
         if isinstance(message, dict):

--- a/mloggers/multi_logger.py
+++ b/mloggers/multi_logger.py
@@ -11,6 +11,7 @@ class MultiLogger(Logger):
         self,
         loggers: list[Logger],
         default_mask: list[type[Logger]] = [],
+        default_level: LogLevel | int = LogLevel.INFO,
     ):
         """
         Initializes a multi-logger.
@@ -19,10 +20,30 @@ class MultiLogger(Logger):
         ----------
         `loggers`: a list of the initialized loggers to use.
         `default_mask`: the default mask to use when logging.
+        `default_level`: the default log level to use.
         """
 
+        super().__init__(default_level)
+        
         self._loggers = loggers
         self._default_mask = default_mask
+
+        for logger in self._loggers:
+            logger.set_level(self._log_level)
+
+    def set_level(self, level: LogLevel | int):
+        """
+        Sets the log level of the multi-logger.
+
+        ### Parameters
+        ----------
+        `level`: the level to set.
+        """
+
+        super(MultiLogger, self).set_level(level)
+
+        for logger in self._loggers:
+            logger.set_level(self._log_level)
 
     def log(
         self,
@@ -111,6 +132,9 @@ class MultiLogger(Logger):
         """
 
         self.log(message, LogLevel.WARN, mask, *args, **kwargs)
+    
+    # Alias warning to warn
+    warning = warn
 
     def error(
         self,

--- a/mloggers/wandb_logger.py
+++ b/mloggers/wandb_logger.py
@@ -16,6 +16,7 @@ class WandbLogger(Logger):
         project: str,
         group: str,
         experiment: str,
+        default_level: LogLevel | int = LogLevel.INFO,
         config: DictConfig | None = None,
     ):
         """
@@ -26,8 +27,11 @@ class WandbLogger(Logger):
         `project`: the name of the project to log to.
         `group`: the name of the group to log to.
         `experiment`: the name of the experiment to log to.
+        `default_level`: the default log level to use.
         [optional] `config`: the configuration of the experiment.
         """
+
+        super().__init__(default_level)
 
         if config is not None:
             config = vars(config)
@@ -40,7 +44,8 @@ class WandbLogger(Logger):
         *args: Any,
         **kwargs: Any,
     ):
-        super(WandbLogger, self).log(message, level, *args, **kwargs)
+        if not super(WandbLogger, self).log(message, level, *args, **kwargs):
+            return
 
         if isinstance(message, dict):
             log = message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mloggers"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
     { name = "Sergio Hernandez Gutierrez", email = "contact.sergiohernandez@gmail.com" },
+    { name = "Matteo Merler", email = "matteo.merler@gmail.com" },
 ]
 description = "A collection of loggers well-suited for machine learning experiments."
 readme = "README.md"


### PR DESCRIPTION
Added importance levels - each LogLevel now has two attributes, color and level. Level is used to check when to log -> if a logger's current level is set to 0, all levels above zero will print.

Level values:
- INFO: 0
- DEBUG: -1
- WARN: 1
- ERROR: np.inf (always print errors)

No level/string level logs are treated as if they were info (0 importance). 
Added set_level to all loggers to change the logging level.
Tested everything besides wandb logger (don't have an account setup atm) but they should all work

Small bugfixes:
- In FileLogger creating a log in the current directory (with no dir path) wouldn't work
- Added an alias command for warning to rederect to warn (e.g. logger.warning = logger.warn)