### PR TITLE
Added support for multiple arguments in logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,23 @@ The available methods to log messages are:
 
 In the case of the `MultiLogger`, the methods above have the additional optional argument `mask`, which can be used to prevent the given message from being propagated through the masked loggers.
 
+All logging functions support multiple arguments, similar to the print function. For example, `logger.info("The value of x is", x)` will log the message `"The value of x is 42"` if `x = 42`.
+The input messages can also be a series of dictionaries, which will be all logged in separate log entries. If the logger is given both a dictionary and a string, it will fail.
+
 ### Masks
 
 Masks are used by the `MultiLogger` to filter loggers which are not supposed to record a given message. At the time of initialization, you can define a default mask to use for all messages for which a mask is not specified when calling `MultiLogger.log(message, level, mask)` or the level-specific variants. To create a mask, simply pass as argument a list of the class references for the loggers you would like to mask out.
+
+### Level filtering
+
+Any logger is initialized with a `default_level` argument, which is set to `LogLevel.INFO` by default. `LogLevel` elements have an `importance` attribute, which defines a hierarchy of levels. When a logger is initialized with a given level, it will only log messages with a level of equal or higher importance. For example, if a logger is initialized with `LogLevel.WARN`, it will log messages with levels `WARN` and `ERROR`, but not `INFO` or `DEBUG`.
+
+The importance values for the built-in levels are:
+
+- `DEBUG`: -1
+- `INFO`: 0
+- `WARN`: 1
+- `ERROR`: `np.inf` (as errors should always be logged)
 
 ### Progress bars
 

--- a/mloggers/logger.py
+++ b/mloggers/logger.py
@@ -32,9 +32,8 @@ class Logger(ABC):
     @abstractmethod
     def log(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         level: LogLevel | str | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -42,7 +41,8 @@ class Logger(ABC):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -50,19 +50,30 @@ class Logger(ABC):
         `level`: the level of the message (e.g., INFO, WARN, ERROR, DEBUG, etc.).
         - If None, no level will be printed.
         - If a string is provided, it will be colored in green (when colors are used) and uppercased; otherwise, the color will be the one associated with the `LogLevel` at time of registration.
+        - If multiple messages are provided, they must be either all strings or all dictionaries. Strings will be joined into a single string, while dictionaries will be printed as separate log entries.
 
         ### Raises
         ----------
         `TypeError`: if the message is not a string, a dictionary or does not implement `__str__()`.
+        `TypeError`: if the messages are a mix of strings and dictionaries.
         """
 
-        if (
-            not isinstance(message, dict)
-            and not hasattr(message, "__str__")
-            and not callable(getattr(message, "__str__"))
-        ):
+        # Check if the messages are of the correct type.
+        for message in messages:
+            if (
+                not isinstance(message, dict)
+                and not hasattr(message, "__str__")
+                and not callable(getattr(message, "__str__"))
+            ):
+                raise TypeError(
+                    f"Expected message to be a string, a dictionary or to have implemented __str__(), but got {type(message)}."
+                )
+        
+        # Check if there is both a string and a dictionary in the messages.
+        if any(isinstance(message, dict) for message in messages) and any(
+            not isinstance(message, dict) for message in messages):
             raise TypeError(
-                f"Expected message to be a string, a dictionary or to have implemented __str__(), but got {type(message)}."
+                "Expected all messages to be either strings or dictionaries, but got a mix of both."
             )
 
         # Filter out messages with a lower importance level than the current log level.
@@ -91,8 +102,7 @@ class Logger(ABC):
 
     def info(
         self,
-        message: str | dict[str, Any],
-        *args: Any,
+        *messages: str | dict[str, Any],
         **kwargs: Any,
     ):
         """
@@ -100,19 +110,19 @@ class Logger(ABC):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
             - You can provide None dictionary values to mean that the key is a header or title of the message.
         """
 
-        self.log(message, LogLevel.INFO, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.INFO, **kwargs)  # type:ignore[reportArgumentType]
 
     def warn(
         self,
-        message: str | dict[str, Any],
-        *args: Any,
+        *messages: str | dict[str, Any],
         **kwargs: Any,
     ):
         """
@@ -120,22 +130,22 @@ class Logger(ABC):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
             - You can provide None dictionary values to mean that the key is a header or title of the message.
         """
 
-        self.log(message, LogLevel.WARN, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.WARN, **kwargs)  # type:ignore[reportArgumentType]
 
     # Alias warning to warn
     warning = warn
 
     def error(
         self,
-        message: str | dict[str, Any],
-        *args: Any,
+        *messages: str | dict[str, Any],
         **kwargs: Any,
     ):
         """
@@ -143,19 +153,19 @@ class Logger(ABC):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
             - You can provide None dictionary values to mean that the key is a header or title of the message.
         """
 
-        self.log(message, LogLevel.ERROR, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.ERROR, **kwargs)  # type:ignore[reportArgumentType]
 
     def debug(
         self,
-        message: str | dict[str, Any],
-        *args: Any,
+        *messages: str | dict[str, Any],
         **kwargs: Any,
     ):
         """
@@ -163,11 +173,12 @@ class Logger(ABC):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
             - You can provide None dictionary values to mean that the key is a header or title of the message.
         """
 
-        self.log(message, LogLevel.DEBUG, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.DEBUG, **kwargs)  # type:ignore[reportArgumentType]

--- a/mloggers/multi_logger.py
+++ b/mloggers/multi_logger.py
@@ -47,10 +47,9 @@ class MultiLogger(Logger):
 
     def log(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         level: LogLevel | str | None = None,
         mask: list[type[Logger]] | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -58,7 +57,8 @@ class MultiLogger(Logger):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -66,12 +66,12 @@ class MultiLogger(Logger):
         `level`: the level of the message (e.g., INFO, WARN, ERROR, DEBUG, etc.).
         - If None, no level will be printed.
         - If a string is provided, it will be colored in green (when colors are used) and uppercased; otherwise, the color will be the one associated with the `LogLevel` at time of registration.
-        `mask`: a list of logger names to not be used to log this message.
-        - If None, the default mask will be used.
+        - If multiple messages are provided, they must be either all strings or all dictionaries. Strings will be joined into a single string, while dictionaries will be printed as separate log entries.
 
         ### Raises
         ----------
         `TypeError`: if the message is not a string, a dictionary or does not implement `__str__()`.
+        `TypeError`: if the messages are a mix of strings and dictionaries.
         """
 
         # NOTE: No need for checking the validity of the message, as the individual loggers will do that.
@@ -85,13 +85,12 @@ class MultiLogger(Logger):
             for logger in self._loggers
             if not any(isinstance(logger, type) for type in mask)
         ]:
-            logger(message, level, *args, **kwargs)
+            logger(*messages, level=level, **kwargs)
 
     def info(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         mask: list[type[Logger]] | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -99,7 +98,8 @@ class MultiLogger(Logger):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -108,13 +108,12 @@ class MultiLogger(Logger):
         - If None, the default mask will be used.
         """
 
-        self.log(message, LogLevel.INFO, mask, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.INFO, mask=mask, **kwargs)  # type:ignore[reportArgumentType]
 
     def warn(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         mask: list[type[Logger]] | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -122,7 +121,8 @@ class MultiLogger(Logger):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -131,16 +131,15 @@ class MultiLogger(Logger):
         - If None, the default mask will be used.
         """
 
-        self.log(message, LogLevel.WARN, mask, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.WARN, mask=mask, **kwargs)  # type:ignore[reportArgumentType]
 
     # Alias warning to warn
     warning = warn
 
     def error(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         mask: list[type[Logger]] | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -148,7 +147,8 @@ class MultiLogger(Logger):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -157,13 +157,12 @@ class MultiLogger(Logger):
         - If None, the default mask will be used.
         """
 
-        self.log(message, LogLevel.ERROR, mask, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.ERROR, mask=mask, **kwargs)  # type:ignore[reportArgumentType]
 
     def debug(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         mask: list[type[Logger]] | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
         """
@@ -171,7 +170,8 @@ class MultiLogger(Logger):
 
         ### Parameters
         ----------
-        `message`: the message to log.
+        `messages`: the messages to log.
+        - These can be any number of messages, separated by commas. They can be of the following types:
         - If a stringifiable object (implements `__str__()`), the message will be logged as-is.
         - If a dictionary, the message will be logged as a JSON string.
             - The dictionary must be JSON serializable.
@@ -180,4 +180,4 @@ class MultiLogger(Logger):
         - If None, the default mask will be used.
         """
 
-        self.log(message, LogLevel.DEBUG, mask, *args, **kwargs)  # type:ignore[reportArgumentType]
+        self.log(*messages, level=LogLevel.DEBUG, mask=mask, **kwargs)  # type:ignore[reportArgumentType]

--- a/mloggers/wandb_logger.py
+++ b/mloggers/wandb_logger.py
@@ -64,6 +64,7 @@ class WandbLogger(Logger):
         if isinstance(message, dict):
             log = message
         else:
+            message = str(message) # This should be safe here as the super should have already checked that the message is a string or has a __str__ method.
             if level is not None:
                 level_str = (
                     level.name if isinstance(level, LogLevel) else str(level).upper()

--- a/mloggers/wandb_logger.py
+++ b/mloggers/wandb_logger.py
@@ -39,13 +39,27 @@ class WandbLogger(Logger):
 
     def log(
         self,
-        message: str | dict[str, Any],
+        *messages: str | dict[str, Any],
         level: LogLevel | str | None = None,
-        *args: Any,
         **kwargs: Any,
     ):
-        if not super(WandbLogger, self).log(message, level, *args, **kwargs):
+        if not super(WandbLogger, self).log(*messages, level=level, **kwargs):
             return
+        
+        # Handle multiple messages
+        if len(messages) > 1:
+            messages = list(messages)
+            # If the messages are strings, join them into a single string.
+            if all(hasattr(message, "__str__") and callable(getattr(message, "__str__"))
+                   and not isinstance(message, dict) for message in messages):
+                message = " ".join([str(message) for message in messages])
+            # If the messages are dictionaries, log them separately.
+            else:
+                for message in messages:
+                    self.log(message, level=level)
+                return
+        else:
+            message = messages[0]
 
         if isinstance(message, dict):
             log = message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mloggers"
-version = "1.1.8"
+version = "1.2.0"
 authors = [
     { name = "Sergio Hernandez Gutierrez", email = "contact.sergiohernandez@gmail.com" },
     { name = "Matteo Merler", email = "matteo.merler@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mloggers"
-version = "1.1.7"
+version = "1.1.8"
 authors = [
     { name = "Sergio Hernandez Gutierrez", email = "contact.sergiohernandez@gmail.com" },
     { name = "Matteo Merler", email = "matteo.merler@gmail.com" },


### PR DESCRIPTION
All loggers now support multiple inputs using the *messages parameter. Any number of strings/dictionaries can be passed through.

If multiple strings are passed, they are concatenated together. If multiple dicts are passed, they are logged separately. If a mix is passed, an error is raised.

Updated readme to reflect new changes. Also caught a small bug in wandb logger where the message wasn't being converted to a string, so for example if a class with __str__ method was being passed it wasn't being converted.

Everything should be tested for all three loggers and all LogLevels. I thought about implementing automatic tests but it doesn't seem worth the work for now, but maybe good to keep in mind later. Also for future PRs it could be good to make a dev branch so I don't have to PR straight to master.